### PR TITLE
Don't copy dependency DLLs to output folder

### DIFF
--- a/SolarSailNavigator.csproj
+++ b/SolarSailNavigator.csproj
@@ -33,35 +33,59 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\..\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="PersistentThrust">
       <HintPath>..\PersistentThrust\Plugin\PersistentThrust.dll</HintPath>
+      <Private>false</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Data">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
       <HintPath>..\..\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
       <HintPath>..\..\KSP_x64_Data\Managed\UnityEngine.InputModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\..\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi @JarredEagley,

## Problem

While reviewing this mod for KSP-CKAN/NetKAN#9488, I noticed that the ZIP file contains many, many extra DLL files, some of which are from KSP and probably not allowed to redistribute:

<details><summary>Click to expand large screenshot</summary>

![image](https://user-images.githubusercontent.com/1559108/220203214-25958fa5-f5eb-4dec-97a8-b6f19cc244b6.png)

</details>

There was some discussion of duplicate DLLs on the forum thread, which was probably about this.

## Cause

The .NET build system unfortunately does this by default unless you set a reference's `Private` property to `false`.

## Changes

This pull request updates the `csproj` file to no longer copy the dependency DLLs. In my testing I get a clean `Plugin` folder containing only `SolarSailNavigator.dll`.
